### PR TITLE
Try writing elevator tests

### DIFF
--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -6,11 +6,13 @@ package frc.robot.subsystems;
 
 import com.revrobotics.spark.SparkFlex;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.sim.SparkFlexSim;
 
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
-public class ElevatorSubsystem extends SubsystemBase {
+public class ElevatorSubsystem extends SubsystemBase implements AutoCloseable {
   // motor (neo vortex according to co-engineering pres?)
   private SparkFlex m_elevatorMotor = new SparkFlex(0, MotorType.kBrushless);
   // pid
@@ -39,5 +41,15 @@ public class ElevatorSubsystem extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+  }
+
+  public SparkFlexSim getSimMotor() {
+    return new SparkFlexSim(m_elevatorMotor,
+      DCMotor.getNeoVortex(1));
+  }
+
+  @Override
+  public void close() {
+    m_elevatorMotor.close();
   }
 }

--- a/src/test/java/TestElevatorSubsystem.java
+++ b/src/test/java/TestElevatorSubsystem.java
@@ -1,0 +1,50 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import edu.wpi.first.hal.HAL;
+import frc.robot.subsystems.ElevatorSubsystem;
+import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.sim.SparkFlexSim;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestElevatorSubsystem {
+    private ElevatorSubsystem m_elevatorSubsystem;
+    private SparkFlexSim m_simElevatorMotor;
+
+    @BeforeEach
+    public void setup() {
+        assert(HAL.initialize(500, 0));
+        m_elevatorSubsystem = new ElevatorSubsystem();
+        m_simElevatorMotor = m_elevatorSubsystem.getSimMotor();  
+    }
+
+    @Test
+    public void testPower() {        
+        assertEquals(m_simElevatorMotor.getAppliedOutput(), 0.0);
+        m_elevatorSubsystem.setPower(0.5);
+        assertEquals(m_simElevatorMotor.getAppliedOutput(), 0.5);
+        m_elevatorSubsystem.setPower(1.0);
+        assertEquals(m_simElevatorMotor.getAppliedOutput(), 1.0);
+    }
+
+    @Test void testPosition() {
+        assertEquals(m_simElevatorMotor.getSetpoint(), 0);
+        m_elevatorSubsystem.setPosition(0.5);
+        assertEquals(m_simElevatorMotor.getSetpoint(), 0.5);
+        m_elevatorSubsystem.setPosition(1.0);
+        assertEquals(m_simElevatorMotor.getSetpoint(), 1.0);
+    }
+
+    @Test void testPosition2() {
+        m_elevatorSubsystem.setPosition(1.0);
+        for (int i = 0; i < 100; i++) {
+            m_elevatorSubsystem.simulationPeriodic();
+        }
+        assertEquals(m_simElevatorMotor.getPosition(), 1.0, 0.02);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        m_elevatorSubsystem.close();
+    }
+}


### PR DESCRIPTION
This change adds a few unit tests for the elevator as an example of how we can add unit tests.

These tests will fail right now because the elevator implementation is incomplete.

See also https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/unit-testing.html

